### PR TITLE
Add SUSE autoyast support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 lang: "en_US.UTF-8"
 keyboard: "fi-latin1"
+autoyast_keyboard: finnish
 timezone: "Europe/Helsinki"
 kickstart_packagesfile: "templates/kickstart-packages.j2"
 kickstart_postfiles:
@@ -10,3 +11,4 @@ dhcp_hosts_file: "/etc/hosts"
 use_dhcp: false
 use_pxe: false
 use_kickstart: true
+use_autoyast: false

--- a/files/boot.py
+++ b/files/boot.py
@@ -30,11 +30,13 @@ try:
             pass
 
     f.close()
-    kickstart = ""
+    bootstrap = ""
     if "kickstart_url" in nodesettings:
-        kickstart = " ks=" + nodesettings["kickstart_url"]
+        bootstrap = " ks=" + nodesettings["kickstart_url"] + " ksdevice=bootif kssendmac"
+    elif "autoyast_url" in nodesettings:
+        bootstrap = " autoyast=" + nodesettings["autoyast_url"] + " install=" + nodesettings["autoyast_install_url"]
     print "#!ipxe"
-    print "kernel " + nodesettings["kernel_url_path"] + "/" + nodesettings.get("kernel_name", "vmlinuz") + kickstart + " edd=off ksdevice=bootif kssendmac console=ttyS1,115200 console=tty0 initrd=" + nodesettings.get("initrd_name", "initrd.img") + " " + nodesettings.get("extra_kernel_params", "")
+    print "kernel " + nodesettings["kernel_url_path"] + "/" + nodesettings.get("kernel_name", "vmlinuz") + bootstrap + " edd=off console=ttyS1,115200 console=tty0 initrd=" + nodesettings.get("initrd_name", "initrd.img") + " " + nodesettings.get("extra_kernel_params", "")
     print "initrd " + nodesettings["kernel_url_path"] + "/" + nodesettings.get("initrd_name", "initrd.img")
     print "boot"
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,9 +8,13 @@
   when: use_pxe
 
 - name: Create kickstart file
-  template: src=kickstart.j2 dest="/var/www/html/kickstart/{{ inventory_hostname_short }}.ks"
+  template: src=kickstart.j2 dest="/var/www/html/bootstrap/{{ inventory_hostname_short }}.ks"
   when: use_pxe and use_kickstart
 
+- name: Create autoyast file
+  template: src=autoyast.j2 dest="/var/www/html/bootstrap/{{ inventory_hostname_short }}.xml"
+  when: use_pxe and use_autoyast
+  
 - name: Find all the configs in dhcpd.d directory
   run_once: true
   find:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,8 +43,8 @@
 - name: Create pxe reinstall directory (to toggle host reinstall)
   file: path=/var/www/provision/reinstall state=directory owner=apache group=apache mode="0755"
 
-- name: Create pxe kickstart directory (kickstart scripts)
-  file: path=/var/www/html/kickstart state=directory owner=apache group=apache mode="0755"
+- name: Create pxe bootstrap script directory
+  file: path=/var/www/html/bootstrap state=directory owner=apache group=apache mode="0755"
 
 - name: Reset selinux context for pxe directory
   command: restorecon -Rv /var/www/provision/

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,12 @@
 - name: Install tftp-server
   yum: name='tftp-server' state='present'
 
+- name: Ensure httpd is always running
+  service:
+    name: httpd
+    state: started
+    enabled: yes
+
 - name: Enable tftp
   lineinfile: dest=/etc/xinetd.d/tftp regexp="disable" line="        disable                 = no"
   notify:

--- a/templates/autoyast.j2
+++ b/templates/autoyast.j2
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_halt config:type="boolean">false</final_halt>
+      <final_reboot config:type="boolean">true</final_reboot>
+      <halt config:type="boolean">false</halt>
+      <second_stage config:type="boolean">true</second_stage>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">false</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">false</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">false</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <groups config:type="list"/>
+  <keyboard>
+    <keymap>{{ autoyast_keyboard }}</keymap>
+  </keyboard>
+  <login_settings/>
+  <networking>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+      </routes>
+    </routing>
+  </networking>
+  <partitioning config:type="list">
+  {{ autoyast_partitions }}
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">false</show>
+      <timeout config:type="integer">10</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">false</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">false</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">false</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <language>
+    <language>{{ lang }}</language>
+  </language>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>{{ timezone }}</timezone>
+  </timezone>
+  <user_defaults>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups config:type="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>{{ root_password_hash }}</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <filename>deploykey.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+mkdir -p /root/.ssh
+{% for key in root_keys %}
+echo "{{ key }}" >> /root/.ssh/authorized_keys
+{% endfor %}
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </post-scripts>
+  </scripts>
+  <services-manager>
+  <default_target>multi-user</default_target>
+  <services>
+    <enable config:type="list">
+      <service>sshd</service>
+    </enable>
+  </services>
+</services-manager>
+</profile>

--- a/templates/kickstart.j2
+++ b/templates/kickstart.j2
@@ -3,7 +3,8 @@ text
 network
 url --url {{ install_repo }}
 {% for repo in additional_repos %}
-repo --name={{ repo.name }} --baseurl={{ repo.url }}
+{# default(omit) doesn't work in templates. the ternary filter thing is a workaround #}
+repo --name={{ repo.name }} --baseurl={{ repo.url }} {{ (repo.options is defined) | ternary(repo.options, '') }}
 {% endfor %}
 lang {{ lang }}
 keyboard {{ keyboard }}

--- a/templates/node_pxe.conf.j2
+++ b/templates/node_pxe.conf.j2
@@ -1,5 +1,9 @@
 {% if use_kickstart %}
-kickstart_url={{ kickstart_url | default('http://' + dhcp_server_ip + '/kickstart/' + inventory_hostname_short + '.ks')}}
+kickstart_url={{ kickstart_url | default('http://' + dhcp_server_ip + '/bootstrap/' + inventory_hostname_short + '.ks')}}
+{% endif %}
+{% if use_autoyast %}
+autoyast_url={{ autoyast_url | default('http://' + dhcp_server_ip + '/bootstrap/' + inventory_hostname_short + '.xml')}}
+autoyast_install_url={{ autoyast_install_url }}
 {% endif %}
 kernel_url_path={{ kernel_url_path }}
 {% if extra_kernel_params is defined %}


### PR DESCRIPTION
This changeset adds support for SLES autoyast bootstrapping. A autoyast file
provided by SUSE (to be as minimal as possible but working in all
situations) is used as a template. The kickstart/autoyast script directory is
renamed to bootstrap (located under /var/www/html).
The variable use_kickstart is true by default so that this role will produce
kickstart files by default if you enable use_pxe for a host.